### PR TITLE
Exits! Package manager errors are suppressed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here's how to use this script.
 Your server must already have:
 
 1. A web server (e.g. Apache or Nginx)
-2. PHP 5.4+
+2. PHP 5.4, 5.5 or 5.6
 3. HelpSpot license file much be present on the server file system. Usually named `license.txt`.
 4. Create a database in MySQL with the following statement (adjust the database name as needed):
 

--- a/install.sh
+++ b/install.sh
@@ -69,12 +69,12 @@ pkg_manager () {
       # APT PRESENT
       INSTALLER="$APT"
       echo "Installing lsb_release command"
-      $INSTALLER install -y curl lsb-core &> /dev/null
+      $INSTALLER install -y curl lsb-core > /dev/null
     else
       # YUM PRESENT
       INSTALLER="$YUM"
       echo "Installing lsb_release command"
-      $INSTALLER install -y curl redhat-lsb-core &> /dev/null
+      $INSTALLER install -y curl redhat-lsb-core > /dev/null
     fi
 }
 


### PR DESCRIPTION
My installer was exiting without any error, after showing "Installing lsb_release command", leaving me clueless.
I checked the installer and tried `sudo apt install -y curl lsb-core`. It showed some package manager errors like

```
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/l/lsb/lsb-core_4.1+Debian11ubuntu6.1_amd64.deb  404  Not Found [IP: 91.189.88.161 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

I think it'd be better to let user know what's going on rather than suppressing (or `&>` redirecting) everything.
